### PR TITLE
Pr for b113538

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -793,7 +793,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     const SliderComponentShape defaultOverlayShape = RoundSliderOverlayShape();
     const SliderComponentShape defaultThumbShape = RoundSliderThumbShape();
     final SliderComponentShape defaultValueIndicatorShape = defaults.valueIndicatorShape!;
-    const ShowValueIndicator defaultShowValueIndicator = ShowValueIndicator.onlyForDiscrete;
+    const ShowValueIndicator defaultShowValueIndicator = ShowValueIndicator.always;
     const SliderInteraction defaultAllowedInteraction = SliderInteraction.tapAndSlide;
 
     final Set<MaterialState> states = <MaterialState>{


### PR DESCRIPTION
This PR makes change to defaultShowValueIndicator const inside slider.dart. This change ensures that the value indicator is displayed when focused for both continuous and discrete sliders. 

