### PR TITLE
Addressed Ambiguity in transform.scale constructor docs 

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1368,10 +1368,9 @@ class Transform extends SingleChildRenderObjectWidget {
   }) : transform = Matrix4.translationValues(offset.dx, offset.dy, 0.0),
        origin = null,
        alignment = null;
-
   /// Creates a widget that scales its child along the 2D plane.
   ///
-  /// The `scaleX` argument provides the scalar by which to multiply the `x` axis, and the `scaleY` argument provides the scalar by which to multiply the `y` axis. Either may be omitted, in which case that axis defaults to 1.0.
+  /// The `scaleX` argument provides the scalar by which to multiply the `x` axis, and the `scaleY` argument provides the scalar by which to multiply the `y` axis. Either may be omitted, in which case the scaling factor for that axis defaults to 1.0.
   ///
   /// For convenience, to scale the child uniformly, instead of providing `scaleX` and `scaleY`, the `scale` parameter may be used.
   ///


### PR DESCRIPTION
This PR updates the docs for Transform.Scale constructor by clearing up some ambiguity regarding how the scaling factor is affected by the omission of a value given you provide scaleX and scaleY as arguments as opposed to just scale. 